### PR TITLE
Refine logging

### DIFF
--- a/addons/pinniped/config-controller/main.go
+++ b/addons/pinniped/config-controller/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 
+	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
 
 	"github.com/go-logr/logr"
@@ -19,8 +20,10 @@ import (
 )
 
 func main() {
-	setupLog := ctrl.Log.WithName("Pinniped Config Controller Set Up")
-	setupLog.Info("starting")
+	klog.InitFlags(nil)
+	ctrl.SetLogger(klogr.New())
+	setupLog := ctrl.Log.WithName("pinniped config controller").WithName("set up")
+	setupLog.Info("starting set up")
 	if err := reallyMain(setupLog); err != nil {
 		setupLog.Error(err, "error running controller")
 		os.Exit(1)
@@ -41,7 +44,6 @@ func reallyMain(setupLog logr.Logger) error {
 	}
 
 	// Create manager to run our controller.
-	ctrl.SetLogger(klogr.New())
 	manager, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
 	})
@@ -56,7 +58,7 @@ func reallyMain(setupLog logr.Logger) error {
 	}
 
 	// Tell manager to start running our controller.
-	setupLog.Info("starting manager")
+	setupLog.V(1).Info("starting manager")
 	if err := manager.Start(ctrl.SetupSignalHandler()); err != nil {
 		return fmt.Errorf("unable to start manager: %w", err)
 	}

--- a/addons/pinniped/config-controller/utils/utils.go
+++ b/addons/pinniped/config-controller/utils/utils.go
@@ -6,7 +6,6 @@ package utils
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -80,7 +79,7 @@ func ClusterHasLabel(label string, logger logr.Logger) predicate.Funcs {
 
 // processIfClusterHasLabel determines if the input object is a cluster with a non-empty
 // value for the specified label. For other input object types, it returns true
-func processIfClusterHasLabel(label string, obj client.Object, logger logr.Logger) bool {
+func processIfClusterHasLabel(label string, obj client.Object, log logr.Logger) bool {
 	kind := obj.GetObjectKind().GroupVersionKind().Kind
 
 	if kind != constants.ClusterKind {
@@ -94,7 +93,9 @@ func processIfClusterHasLabel(label string, obj client.Object, logger logr.Logge
 		}
 	}
 
-	log := logger.WithValues("namespace", obj.GetNamespace(), strings.ToLower(kind), obj.GetName())
-	log.V(6).Info("Cluster resource does not have label", "label", label)
+	log.V(1).Info("Cluster resource does not have label",
+		"label", label,
+		constants.NamespaceLogKey, obj.GetNamespace(),
+		constants.NameLogKey, obj.GetName())
 	return false
 }


### PR DESCRIPTION
Mostly followed guidelines here: https://github.com/kubernetes-sigs/controller-runtime/blob/9ee63fc65a9720568f74df9901b16883621636b4/TMP-LOGGING.md

I thought about adding some sort of small unit test to verify we are able to set the log level (in case someone tried to remove this line: `klog.InitFlags(nil)`), but wasn't sure if we really needed it, let me know what you all think.

Oh, also, it still logs a good bit, but I found it nice to see how often it was actually hitting our reconcile and what the result of the reconcile was.  We can change this if it seems like too much though. 
