### PR TITLE
Fix pinniped-info configmap reconciliation

### DIFF
--- a/addons/pinniped/config-controller/controllers/controller_test.go
+++ b/addons/pinniped/config-controller/controllers/controller_test.go
@@ -298,12 +298,25 @@ var _ = Describe("Controller", func() {
 				create(ctx, configMap)
 			})
 
-			It("loops through all the addons secrets", func() {
+			It("updates all the addons secrets", func() {
 				for _, c := range clusters {
 					Eventually(addonSecretFunc(ctx, c, configMap)).Should(Succeed())
 				}
 			})
+
+			When("the configmap gets deleted", func() {
+				BeforeEach(func() {
+					delete(ctx, configMap)
+				})
+
+				It("updates all the addons secrets", func() {
+					for _, c := range clusters {
+						Eventually(addonSecretFunc(ctx, c, nil)).Should(Succeed())
+					}
+				})
+			})
 		})
+
 		When("a configmap in a different namespace gets created", func() {
 			// TODO: Add info to CM and make sure it doesn't get propagated to secrets
 			BeforeEach(func() {

--- a/addons/pinniped/config-controller/controllers/controllers.go
+++ b/addons/pinniped/config-controller/controllers/controllers.go
@@ -46,8 +46,6 @@ func NewController(c client.Client) *PinnipedController {
 }
 
 func (c *PinnipedController) SetupWithManager(manager ctrl.Manager) error {
-	// CM gets deleted: do nothing for now...should it get logged?
-	// CM generic func: do nothing
 	// Addons secret deleted: recreate it User only manages addons secret on mgmt cluster
 
 	err := ctrl.
@@ -76,7 +74,7 @@ func (c *PinnipedController) SetupWithManager(manager ctrl.Manager) error {
 }
 
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=list;watch;get;patch;update;delete
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=watch;get
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=list;watch;get
 // +kubebuilder:rbac:groups="cluster.x-k8s.io",resources=clusters,verbs=list;watch;get
 
 func (c *PinnipedController) Reconcile(ctx context.Context, req ctrl.Request) (reconcile.Result, error) {
@@ -100,7 +98,7 @@ func (c *PinnipedController) Reconcile(ctx context.Context, req ctrl.Request) (r
 	}
 	// if req is empty, CM changed, let's loop through all clusters and create/update/delete secrets
 	if (req == ctrl.Request{}) {
-		log.V(1).Info("empty request provided, checking all clusters")
+		log.V(1).Info("configmap changed, checking all clusters")
 		clusters := &clusterapiv1beta1.ClusterList{}
 		if err := c.client.List(ctx, clusters); err != nil {
 			log.Error(err, "error listing clusters")

--- a/addons/pinniped/config-controller/controllers/handlers.go
+++ b/addons/pinniped/config-controller/controllers/handlers.go
@@ -20,8 +20,7 @@ import (
 
 func (c *PinnipedController) configMapToCluster(o client.Object) []ctrl.Request {
 	// return empty object, if pinniped-info CM changes, update all the secrets
-	c.Log.V(1).Info("configmap created/updated/deleted, sending back empty request to reconcile all clusters")
-	return []ctrl.Request{}
+	return []ctrl.Request{{}}
 }
 
 func withNamespacedName(namespacedName types.NamespacedName) builder.Predicates {
@@ -34,7 +33,7 @@ func withNamespacedName(namespacedName types.NamespacedName) builder.Predicates 
 			UpdateFunc: func(e event.UpdateEvent) bool {
 				return isNamespacedName(e.ObjectOld) || isNamespacedName(e.ObjectNew)
 			},
-			DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+			DeleteFunc:  func(e event.DeleteEvent) bool { return isNamespacedName(e.Object) },
 			GenericFunc: func(e event.GenericEvent) bool { return isNamespacedName(e.Object) },
 		},
 	)

--- a/addons/pinniped/config-controller/manifests/role.yaml
+++ b/addons/pinniped/config-controller/manifests/role.yaml
@@ -11,6 +11,7 @@ rules:
   - configmaps
   verbs:
   - get
+  - list
   - watch
 - apiGroups:
   - ""


### PR DESCRIPTION
### What this PR does / why we need it
Discovered during validation that changes to the pinniped-info configmap are returning true for reconciliation, but the request does not get passed to our reconcile function. It looks like it is not sending through the reconciliation request since it's empty (which is weird since it seems to pass in our tests).

Also, we are currently sending through false when the configmap gets deleted, but we should probably send true so the secrets can go back to `identity_management_type: none`
